### PR TITLE
Fix custom type not loaded

### DIFF
--- a/lib/type.ex
+++ b/lib/type.ex
@@ -241,6 +241,8 @@ defmodule Skema.Type do
 
   # if custom type provide cast function, use it
   defp maybe_cast_custom_type(mod, value) do
+    Code.ensure_loaded?(mod)
+
     if function_exported?(mod, :cast, 1) do
       mod.cast(value)
     else

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Skema.MixProject do
   def project do
     [
       app: :skema,
-      version: "0.2.1",
+      version: "0.2.2",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/defschema_test.exs
+++ b/test/defschema_test.exs
@@ -2,7 +2,6 @@ defmodule DefSchemaTest do
   use ExUnit.Case
   use Skema
 
-
   describe "defschema module with default value" do
     defschema User do
       field(:name, :string, required: true)
@@ -11,11 +10,32 @@ defmodule DefSchemaTest do
     end
 
     test "new with default value" do
-      assert  %User{age: 10, name: nil, email: nil} = User.new(%{})
+      assert %User{age: 10, name: nil, email: nil} = User.new(%{})
     end
 
     test "new override default value" do
-      assert  %User{age: 18, name: "Donkey", email: nil} = User.new(%{age: 18, name: "Donkey"})
+      assert %User{age: 18, name: "Donkey", email: nil} = User.new(%{age: 18, name: "Donkey"})
+    end
+  end
+
+  describe "test custom ecto type" do
+    defmodule CustomType do
+      @moduledoc false
+      def cast(value) when is_binary(value), do: {:ok, value}
+      def cast(_), do: :error
+    end
+
+    defschema User2 do
+      field(:name, :string, required: true)
+      field(:status, CustomType)
+    end
+
+    test "cast custom type" do
+      assert {:ok, %User2{name: "D", status: "active"}} = %{name: "D", status: "active"} |> User2.cast() |> IO.inspect()
+    end
+
+    test "cast custom type with invalid value" do
+      assert {:error, %{errors: %{status: ["is invalid"]}}} = User2.cast(%{name: "D", status: 1})
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a capability to ensure custom types are loaded before casting in the `Skema.Type` module.
	- Added test scenarios for overriding default values and custom Ecto type casting in schemas.

- **Chores**
	- Updated the project version to "0.2.2".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->