### PR TITLE
Support direct constraint format in JSON Schema converter

### DIFF
--- a/lib/schema_helper.ex
+++ b/lib/schema_helper.ex
@@ -1,5 +1,20 @@
 defmodule Skema.SchemaHelper do
-  @moduledoc false
+  @moduledoc """
+  Internal utility module for processing and expanding schema definitions.
+
+  This module handles the normalization and expansion of schema field definitions,
+  converting shorthand syntax into fully expanded attribute lists. It processes
+  nested schemas, array types, and evaluates function-based default values.
+
+  ## Key Functions
+
+  - `expand/1` - Transforms a schema map by expanding each field definition
+  - Field normalization from shorthand to full attribute syntax
+  - Recursive processing of nested schemas and array types
+  - Default value evaluation for function-based defaults
+
+  This module is internal to Skema and not part of the public API.
+  """
 
   @spec expand(map()) :: map()
   def expand(schema) do


### PR DESCRIPTION
Add support for Skema's new direct constraint syntax (min_length, max_length, min_items, max_items, min, max, greater_than, less_than) in JSON Schema conversion. Direct constraints take precedence over nested format when both are present.

Changes:
- Add direct constraint mappings for length and number constraints
- Refactor constraint handling to use generic mapping function
- Add comprehensive tests for direct constraint support
- Add module documentation for SchemaHelper
- Maintain backward compatibility with nested constraint format

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add support for Skema's direct constraint syntax in the JSON Schema converter, making it take precedence over legacy nested formats and consolidating constraint logic.

New Features:
- Support direct constraints (min_length, max_length, min_items, max_items, min, max, greater_than, less_than) in JSON Schema conversion

Enhancements:
- Refactor constraint application into a generic apply_direct_constraints function and separate nested/exclusive handlers for length and number constraints

Documentation:
- Add comprehensive moduledoc for SchemaHelper outlining its role in schema normalization and expansion

Tests:
- Add tests for direct length and number constraints, precedence over legacy formats, and combined constraint scenarios