### PR TITLE
Fix schema & test

### DIFF
--- a/lib/json_schema/converter/to_skema.ex
+++ b/lib/json_schema/converter/to_skema.ex
@@ -16,22 +16,27 @@ defmodule Skema.JsonSchema.Converter.ToSkema do
   """
   def convert_properties_to_schema(properties, required_fields, opts \\ []) do
     # Set defaults once
-    opts = Keyword.merge([
-      atom_keys: false,
-      strict: false,
-      default_type: :any,
-      per_field_required: false
-    ], opts)
+    opts =
+      Keyword.merge(
+        [
+          atom_keys: false,
+          strict: false,
+          default_type: :any,
+          per_field_required: false
+        ],
+        opts
+      )
 
     Enum.reduce(properties, %{}, fn {field_name, field_schema}, acc ->
       field_key = if opts[:atom_keys], do: String.to_atom(field_name), else: field_name
 
       # Check required based on the per_field_required option
-      is_required = if opts[:per_field_required] do
-        Map.get(field_schema, "required") == true
-      else
-        field_name in required_fields
-      end
+      is_required =
+        if opts[:per_field_required] do
+          Map.get(field_schema, "required") == true
+        else
+          field_name in required_fields
+        end
 
       field_def = convert_json_field_to_skema(field_schema, is_required, opts)
       Map.put(acc, field_key, field_def)
@@ -47,7 +52,7 @@ defmodule Skema.JsonSchema.Converter.ToSkema do
 
     # If type is already a nested schema (map), return it directly
     if is_map(type) do
-      type
+      [type: type]
     else
       field_def = [type: type]
       field_def = if is_required, do: Keyword.put(field_def, :required, true), else: field_def
@@ -87,7 +92,9 @@ defmodule Skema.JsonSchema.Converter.ToSkema do
 
       "object" ->
         case Map.get(field_schema, "properties") do
-          nil -> :map
+          nil ->
+            :map
+
           properties ->
             required = Map.get(field_schema, "required", [])
             convert_properties_to_schema(properties, required, opts)
@@ -104,7 +111,10 @@ defmodule Skema.JsonSchema.Converter.ToSkema do
         if opts[:strict] do
           raise ArgumentError, "JSON Schema field missing required 'type' property: #{inspect(field_schema)}"
         else
-          Logger.warning("JSON Schema field missing 'type' property: #{inspect(field_schema)}. Defaulting to #{inspect(opts[:default_type])}.")
+          Logger.warning(
+            "JSON Schema field missing 'type' property: #{inspect(field_schema)}. Defaulting to #{inspect(opts[:default_type])}."
+          )
+
           opts[:default_type]
         end
 
@@ -112,7 +122,10 @@ defmodule Skema.JsonSchema.Converter.ToSkema do
         if opts[:strict] do
           raise ArgumentError, "Unknown JSON Schema type '#{unknown_type}': #{inspect(field_schema)}"
         else
-          Logger.warning("Unknown JSON Schema type '#{unknown_type}' in field #{inspect(field_schema)}. Defaulting to #{inspect(opts[:default_type])}.")
+          Logger.warning(
+            "Unknown JSON Schema type '#{unknown_type}' in field #{inspect(field_schema)}. Defaulting to #{inspect(opts[:default_type])}."
+          )
+
           opts[:default_type]
         end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Skema.MixProject do
   def project do
     [
       app: :skema,
-      version: "1.4.0",
+      version: "1.4.1",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/json_schema/converter/to_skema_test.exs
+++ b/test/json_schema/converter/to_skema_test.exs
@@ -413,11 +413,13 @@ defmodule Skema.JsonSchema.Converter.ToSkemaTest do
 
       result = JsonSchema.to_schema(json_schema)
 
-      assert is_map(result["profile"])
-      assert result["profile"]["bio"][:type] == :string
-      assert result["profile"]["bio"][:length] == [max: 500]
-      assert result["profile"]["website"][:type] == :string
-      assert result["profile"]["website"][:format] == "^https?://.+"
+      assert is_list(result["profile"])
+      nested_profile = result["profile"][:type]
+      assert is_map(nested_profile)
+      assert nested_profile["bio"][:type] == :string
+      assert nested_profile["bio"][:length] == [max: 500]
+      assert nested_profile["website"][:type] == :string
+      assert nested_profile["website"][:format] == "^https?://.+"
     end
 
     test "handles nested required fields" do
@@ -437,11 +439,13 @@ defmodule Skema.JsonSchema.Converter.ToSkemaTest do
 
       result = JsonSchema.to_schema(json_schema)
 
-      assert is_map(result["profile"])
-      assert result["profile"]["name"][:type] == :string
-      assert result["profile"]["name"][:required] == true
-      assert result["profile"]["bio"][:type] == :string
-      refute result["profile"]["bio"][:required]
+      assert is_list(result["profile"])
+      nested_profile = result["profile"][:type]
+      assert is_map(nested_profile)
+      assert nested_profile["name"][:type] == :string
+      assert nested_profile["name"][:required] == true
+      assert nested_profile["bio"][:type] == :string
+      refute nested_profile["bio"][:required]
     end
   end
 
@@ -499,10 +503,13 @@ defmodule Skema.JsonSchema.Converter.ToSkemaTest do
 
       result = JsonSchema.to_schema(json_schema, atom_keys: true)
 
-      assert result.profile.name[:type] == :string
-      assert result.profile.name[:required] == true
-      assert result.profile.bio[:type] == :string
-      refute result.profile.bio[:required]
+      assert is_list(result.profile)
+      nested_profile = result.profile[:type]
+      assert is_map(nested_profile)
+      assert nested_profile.name[:type] == :string
+      assert nested_profile.name[:required] == true
+      assert nested_profile.bio[:type] == :string
+      refute nested_profile.bio[:required]
     end
   end
 
@@ -559,11 +566,13 @@ defmodule Skema.JsonSchema.Converter.ToSkemaTest do
 
       result = JsonSchema.to_schema(json_schema, per_field_required: true)
 
-      assert is_map(result["profile"])
-      assert result["profile"]["name"][:type] == :string
-      assert result["profile"]["name"][:required] == true
-      assert result["profile"]["bio"][:type] == :string
-      refute result["profile"]["bio"][:required]
+      assert is_list(result["profile"])
+      nested_profile = result["profile"][:type]
+      assert is_map(nested_profile)
+      assert nested_profile["name"][:type] == :string
+      assert nested_profile["name"][:required] == true
+      assert nested_profile["bio"][:type] == :string
+      refute nested_profile["bio"][:required]
     end
 
     test "combines per_field_required with atom_keys option" do

--- a/test/json_schema_test.exs
+++ b/test/json_schema_test.exs
@@ -86,9 +86,11 @@ defmodule Skema.JsonSchemaTest do
       assert converted_schema["tags"][:default] == []
 
       # Check nested schema
-      assert is_map(converted_schema["profile"])
-      assert converted_schema["profile"]["bio"][:type] == :string
-      assert converted_schema["profile"]["bio"][:length] == [max: 500]
+      assert is_list(converted_schema["profile"])
+      nested_profile = converted_schema["profile"][:type]
+      assert is_map(nested_profile)
+      assert nested_profile["bio"][:type] == :string
+      assert nested_profile["bio"][:length] == [max: 500]
     end
 
     test "preserves documentation in round-trip conversion" do
@@ -107,7 +109,8 @@ defmodule Skema.JsonSchemaTest do
       # Should preserve documentation
       assert converted_schema["name"][:doc] == "User's full name"
       assert converted_schema["age"][:doc] == "Age in years"
-      assert converted_schema["profile"]["bio"][:doc] == "Short biography"
+      nested_profile = converted_schema["profile"][:type]
+      assert nested_profile["bio"][:doc] == "Short biography"
     end
 
     test "round-trip conversion with atom_keys option" do
@@ -194,10 +197,11 @@ defmodule Skema.JsonSchemaTest do
       assert converted_schema.user_age[:type] == :integer
       refute converted_schema.user_age[:required]
 
-      assert converted_schema.profile.bio[:type] == :string
-      assert converted_schema.profile.bio[:required] == true
-      assert converted_schema.profile.website[:type] == :string
-      refute converted_schema.profile.website[:required]
+      nested_profile = converted_schema.profile[:type]
+      assert nested_profile.bio[:type] == :string
+      assert nested_profile.bio[:required] == true
+      assert nested_profile.website[:type] == :string
+      refute nested_profile.website[:required]
     end
 
     test "mixing per_field_required with other options" do


### PR DESCRIPTION
## Summary by Sourcery

Wrap nested object schemas in keyword lists with a :type key and update tests accordingly

Bug Fixes:
- Return nested JSON Schema objects as keyword lists containing a :type entry instead of raw maps

Enhancements:
- Reformat Keyword.merge calls and wrap Logger.warning arguments for improved readability
- Bump project version to 1.4.1

Tests:
- Update converter and round-trip tests to assert nested schemas are lists and extract the nested map via the :type key