### PR TITLE
Fix transform

### DIFF
--- a/lib/schema.ex
+++ b/lib/schema.ex
@@ -247,7 +247,7 @@ defmodule Skema.Schema do
       """
       def transform(params) when is_map(params) do
         case Skema.transform(params, @ts_fields_map) do
-          {:ok, data} -> {:ok, new(data)}
+          {:ok, data} -> {:ok, data}
           error -> error
         end
       end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Skema.MixProject do
   def project do
     [
       app: :skema,
-      version: "1.4.1",
+      version: "1.4.2",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Summary by Sourcery

Fix transform/1 to return the transformed data directly and bump the project version

Bug Fixes:
- Return transformed data directly in transform/1 instead of creating a new struct

Build:
- Bump version to 1.4.2