### PR TITLE
Fix transform alway return map

### DIFF
--- a/lib/skema.ex
+++ b/lib/skema.ex
@@ -237,6 +237,6 @@ defmodule Skema do
   end
 
   defp build_transformation_result(schema, data) do
-    Result.new(schema: schema, params: data, valid_data: data)
+    Result.new(schema: schema, params: data, valid_data: Map.from_struct(data))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Skema.MixProject do
   def project do
     [
       app: :skema,
-      version: "1.4.2",
+      version: "1.4.3",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Summary by Sourcery

Fix transformation result to always return a map and bump project version

Bug Fixes:
- Ensure build_transformation_result returns a map by converting structs with Map.from_struct

Build:
- Bump project version to 1.4.3