### PR TITLE
bump version valdi to 0.7

### DIFF
--- a/lib/skema.ex
+++ b/lib/skema.ex
@@ -237,6 +237,8 @@ defmodule Skema do
   end
 
   defp build_transformation_result(schema, data) do
-    Result.new(schema: schema, params: data, valid_data: Map.from_struct(data))
+    valid_data = if is_struct(data), do: Map.from_struct(data), else: data
+
+    Result.new(schema: schema, params: data, valid_data: valid_data)
   end
 end

--- a/lib/skema/transformer.ex
+++ b/lib/skema/transformer.ex
@@ -53,11 +53,8 @@ defmodule Skema.Transformer do
     end
   end
 
-  @doc """
-  Applies a transformation function to a field value.
-
-  Supports multiple function signatures and error handling patterns.
-  """
+  # Applies a transformation function to a field value.
+  # Supports multiple function signatures and error handling patterns.
   @spec apply_transformation(nil | function(), any(), map()) ::
           {:ok, any()} | {:error, any()} | any()
   defp apply_transformation(nil, value, _data), do: {:ok, value}

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Skema.MixProject do
     [
       app: :skema,
       version: "1.4.3",
-      elixir: "~> 1.10",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       test_coverage: [tool: ExCoveralls],
@@ -52,11 +52,10 @@ defmodule Skema.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:valdi, "~> 0.6"},
+      {:valdi, "~> 0.7"},
       {:ex_doc, "~> 0.27", only: [:dev]},
       {:excoveralls, "~> 0.16", only: :test},
-      {:styler, "~> 0.11", only: [:dev, :test], runtime: false},
-      {:decimal, "~> 2.1"}
+      {:styler, "~> 0.11", only: [:dev, :test], runtime: false}
     ]
   end
 end


### PR DESCRIPTION
## Summary by Sourcery

Update dependencies and data handling for Skema transformations.

Bug Fixes:
- Ensure transformation results handle both structs and non-struct data when building valid_data.

Enhancements:
- Raise minimum supported Elixir version requirement to 1.12.
- Bump valdi dependency from 0.6 to 0.7 and remove unused decimal dependency.
- Convert detailed documentation for apply_transformation/3 into comments instead of a public @doc.

Build:
- Adjust mix configuration to reflect updated Elixir and dependency requirements.